### PR TITLE
Fix(devnet): add legacy flag to forge

### DIFF
--- a/devnet/2-deploy-op-contracts.sh
+++ b/devnet/2-deploy-op-contracts.sh
@@ -229,7 +229,7 @@ docker run --rm \
   -v "$PWD_DIR/.env:/app/.env" \
   -v "$PWD_DIR/config-op:/config-op" \
   "${OP_STACK_IMAGE_TAG}" \
-  bash -c "/scripts/setup-cgt-function.sh "/app" "/config-op" "http://l1-geth:8545""
+  bash -c "/scripts/setup-cgt-function.sh /app /config-op ${L1_RPC_URL_IN_DOCKER}"
 
 echo ""
 echo "🎉 Complete setup with Custom Gas Token finished!"

--- a/devnet/clean.sh
+++ b/devnet/clean.sh
@@ -29,6 +29,7 @@ rm -rf l1-geth/consensus/genesis.ssz
 rm -rf l1-geth/consensus/validatordata/
 rm -rf l1-geth/execution/genesis.json
 rm -rf l1-geth/execution/geth/
+rm -rf l1-geth/execution/keystore/
 rm -rf init.log
 
 echo " ✅ Cleanup completed!"

--- a/devnet/docker-compose.yml
+++ b/devnet/docker-compose.yml
@@ -90,9 +90,6 @@ services:
       - --authrpc.addr=0.0.0.0
       - --authrpc.jwtsecret=/execution/jwtsecret
       - --datadir=/execution
-      - --allow-insecure-unlock
-      - --unlock=0x123463a4b065722e99115d6c222f267d9cabb524
-      - --password=/execution/geth_password.txt
       - --nodiscover
       - --syncmode=full
       - --gcmode=archive
@@ -109,7 +106,6 @@ services:
     volumes:
       - ./l1-geth/execution:/execution
       - ./l1-geth/execution/jwtsecret:/execution/jwtsecret
-      - ./l1-geth/execution/geth_password.txt:/execution/geth_password.txt
     healthcheck:
       test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:8545"]
       interval: 10s

--- a/devnet/scripts/setup-cgt-function.sh
+++ b/devnet/scripts/setup-cgt-function.sh
@@ -16,9 +16,6 @@ setup_cgt() {
   local CONFIG_DIR=$2
   local L1_RPC_URL=$3
 
-  echo "🔧 Setting up Custom Gas Token (CGT) configuration..."
-  echo ""
-
   # Check if OKB_TOKEN_ADDRESS is already set in environment
   if [ -n "$OKB_TOKEN_ADDRESS" ]; then
     echo "📝 Step 1: Using existing OKB token..."
@@ -54,6 +51,7 @@ setup_cgt() {
     forge script scripts/DeployMockOKB.s.sol:DeployMockOKB \
       --rpc-url "$L1_RPC_URL" \
       --private-key "$DEPLOYER_PRIVATE_KEY" \
+      --legacy \
       --broadcast 2>&1 | tee $MOCK_OKB_OUTPUT_FILE
     MOCK_OKB_EXIT_CODE=$?
     set -e
@@ -108,6 +106,7 @@ setup_cgt() {
   forge script scripts/SetupCustomGasToken.s.sol:SetupCustomGasToken \
     --rpc-url "$L1_RPC_URL" \
     --private-key "$DEPLOYER_PRIVATE_KEY" \
+    --legacy \
     --broadcast 2>&1 | tee $FORGE_OUTPUT_FILE
   FORGE_EXIT_CODE=$?
   set -e


### PR DESCRIPTION
- This fixes the issue of devnet setup getting stuck at step 2 (this is fixed by adding --legacy to forge script)
- Also removes deprecated parameters from l1 geth 