### PR TITLE
fix(devnet): 2-deploy-contracts.sh blow up due to missing field

### DIFF
--- a/devnet/config-op/intent.toml.bak
+++ b/devnet/config-op/intent.toml.bak
@@ -10,6 +10,7 @@ l2ContractsLocator = "file:///app/packages/contracts-bedrock/forge-artifacts"
   baseFeeVaultRecipient = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
   l1FeeVaultRecipient = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
   sequencerFeeVaultRecipient = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+  operatorFeeVaultRecipient = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
   eip1559DenominatorCanyon = 250
   eip1559Denominator = 50
   eip1559Elasticity = 6


### PR DESCRIPTION
Before, we get this error when `2-deploy-contracts.sh` is run. After adding `operatorFeeVaultRecipient` to intent.toml addresses this problem.

t=2025-11-24T07:41:56+0000 lvl=info msg="Transaction confirmed" service=transactor tx=0x104f671874558314d963cab83d3e6638e731a155a05d45721441ea8f5231176c block=0xe53293b647ceb13e5ee28388e3ab83bac8be77ed9395fd595ced21c4184d3163:81 effectiveGasPrice=1000036015
t=2025-11-24T07:41:56+0000 lvl=info msg="transaction confirmed" id=0xc2f5ab0a277335cecb7a756073642941a592a0e1484eb6f1e1c8ca1716dcb130 completed=29 total=29 hash=0x104f671874558314d963cab83d3e6638e731a155a05d45721441ea8f5231176c nonce=0 creation=0x0000000000000000000000000000000000000000
t=2025-11-24T07:41:56+0000 lvl=info msg="deployed implementations"
 ✅ Updated chain id in intent.toml: 0x00000000000000000000000000000000000000000000000000000000000000c4
 ✅ Updated intent.toml with transactor owner: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 ✅ Updated clock parameters in intent.toml: clockExtension=5, maxClockDuration=40
 ✅ Updated opcmAddress (0x1807a0c850c30913f93e78d647a6ce7c07856445) in intent.toml
🔧 Starting contract deployment with op-deployer...
**Application failed: failed to validate intent-type=standard-overrides: chain has a fee vault set to zero address: chainId=0x00000000000000000000000000000000000000000000000000000000000000c4**